### PR TITLE
fix [proj2a]: make DummyHistoryHandler plot correct parabola

### DIFF
--- a/proj2a/src/main/DummyHistoryHandler.java
+++ b/proj2a/src/main/DummyHistoryHandler.java
@@ -23,7 +23,7 @@ public class DummyHistoryHandler extends NgordnetQueryHandler {
 
         TimeSeries parabola = new TimeSeries();
         for (int i = 1400; i < 1500; i += 1) {
-            parabola.put(i, (i - 50.0) * (i - 50.0) + 3);
+            parabola.put(i, (i - 1450.0) * (i - 1450.0) + 3);
         }
 
         TimeSeries sinWave = new TimeSeries();


### PR DESCRIPTION
Fixes an issue in DummyHistoryHandler where the generated parabola was incorrectly centered at $x = 50$ instead of $x = 1450$. As a result, the parabola unexpectedly dominated the plot, making it difficult or impossible to identify what the plot is.

| Before Fixing | After Fixing |
| :-----------: | :----------: |
| <img style="max-width:100%; height:auto;" alt="before-fixing" src="https://github.com/user-attachments/assets/2cbc055f-2315-4c7c-88de-c92daf4e0357" /> | <img style="max-width:100%; height:auto;" alt="after-fixing" src="https://github.com/user-attachments/assets/528d9ae7-f3f5-46fa-8e45-1111d0b73988" /> |
